### PR TITLE
fizzbuzz: use y combinator to avoid mutation on recursive functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # monad-buzz
-fizzbuzz without out all the sad mutation and interleaved IO
+fizzbuzz without out all the sad mutation and interleaved IO [satire [kinda]]
 
 ## featuring
 
@@ -8,18 +8,43 @@ easily-understandable definition of program behavior
 
 ```js
 /**
- * @return Iterator A lazy iterator that will create and bind one computation per
- *                  iteration. It will return an immutable IO monad after each
- *                  iteration. The final IO monad can be executed at the end of
- *                  the program to build the final output string.
+ * @return Iterator<Truth<Maybe<int>>>
+ *    A lazy iterator that will create and bind one computation per
+ *    iteration. It will return an immutable IO monad after each
+ *    iteration. The final IO monad can be executed at the end of
+ *    the program to build the final output string.
  */
 export default function fizzbuzzer() {
-  return chainTruthGenerator(pass(), range(1, 100), truth => truth
-      .bind(fizzbuzzComp)
-      .bind(fizzComp)
-      .bind(buzzComp)
-      .bind(idComp));
+  return chainTruthGenerator({
+    truth: pass(),
+    generator: range({start: 1, end: 100}),
+    transform: truth => truth
+        .bind(fizzbuzzComp)
+        .bind(fizzComp)
+        .bind(buzzComp)
+        .bind(idComp)
+    });
 }
+```
+
+mutation-free iteration
+
+```js
+/**
+ * Returns an iterator over a range of integers.
+ */
+export const range = yCombinator(self =>
+  function*({ start, end }) {
+    if (start <= end) {
+      yield start;
+      yield* self({
+        start: start + 1,
+        end
+      });
+    }
+  }
+);
+
 ```
 
 beautiful declarative computations
@@ -32,18 +57,4 @@ beautiful declarative computations
 export const buzzComp = compFactory(
     value => value % 5 === 0,
     "buzz");
-```
-
-mutation-free iteration
-
-```js
-/**
- * Returns an iterator over a range of integers.
- */
-export function* range(start, end) {
-  if (start <= end) {
-    yield start;
-    yield* range(start + 1, end);
-  }
-}
 ```

--- a/main.js
+++ b/main.js
@@ -1,8 +1,10 @@
 import fizzbuzzer from './src/fizzbuzz.js';
 import { consoleTruth } from './src/monad-utils.js';
+import yCombinator from './src/y-combinator.js';
 
-let truth;
-
-for (truth of fizzbuzzer()) {}
-
-consoleTruth(truth);
+consoleTruth((yCombinator(self => ({ fizzbuzz, finalTruth }) => {
+  const { done, value } = fizzbuzz.next();
+  return done ? finalTruth : self({ fizzbuzz, finalTruth: value });
+}))({
+  fizzbuzz: fizzbuzzer()
+}));

--- a/src/fizzbuzz.js
+++ b/src/fizzbuzz.js
@@ -18,5 +18,5 @@ export default function fizzbuzzer() {
         .bind(fizzComp)
         .bind(buzzComp)
         .bind(idComp)
-    });
+  });
 }

--- a/src/fizzbuzz.js
+++ b/src/fizzbuzz.js
@@ -9,10 +9,13 @@ import { pass } from './monad-utils.js';
  *                  to create the final output.
  */
 export default function fizzbuzzer() {
-  return chainTruthGenerator(pass(), range({start: 1, end: 100}),
-      truth => truth
-      .bind(fizzbuzzComp)
-      .bind(fizzComp)
-      .bind(buzzComp)
-      .bind(idComp));
+  return chainTruthGenerator({
+    truth: pass(),
+    generator: range({start: 1, end: 100}),
+    transform: truth => truth
+        .bind(fizzbuzzComp)
+        .bind(fizzComp)
+        .bind(buzzComp)
+        .bind(idComp)
+    });
 }

--- a/src/fizzbuzz.js
+++ b/src/fizzbuzz.js
@@ -3,10 +3,11 @@ import { fizzbuzzComp, fizzComp, buzzComp, idComp } from './fizzbuzz-comps.js';
 import { pass } from './monad-utils.js';
 
 /**
- * @return Iterator A lazy iterator that will perform one computation per
- *                  iteration. It will return the current `Truth` at each
- *                  iteration, which can be evaluated at the end of the program
- *                  to create the final output.
+ * @return Iterator<Truth<Maybe<int>>>
+ *    A lazy iterator that will create and bind one computation per
+ *    iteration. It will return an immutable IO monad after each
+ *    iteration. The final IO monad can be executed at the end of
+ *    the program to build the final output string.
  */
 export default function fizzbuzzer() {
   return chainTruthGenerator({

--- a/src/fizzbuzz.js
+++ b/src/fizzbuzz.js
@@ -9,7 +9,8 @@ import { pass } from './monad-utils.js';
  *                  to create the final output.
  */
 export default function fizzbuzzer() {
-  return chainTruthGenerator(pass(), range(1, 100), truth => truth
+  return chainTruthGenerator(pass(), range({start: 1, end: 100}),
+      truth => truth
       .bind(fizzbuzzComp)
       .bind(fizzComp)
       .bind(buzzComp)

--- a/src/generator-utils.js
+++ b/src/generator-utils.js
@@ -9,25 +9,29 @@ import yCombinator from './y-combinator.js';
  * @param Iterator generator An iterator of values to `transform`.
  * @param (Truth -> Truth) transform
  */
-export function* chainTruthGenerator(truth, generator, transform) {
-  const next = generator.next();
+export const chainTruthGenerator = yCombinator(self =>
+  function*({ truth, generator, transform }) {
+    const next = generator.next();
 
-  if (!next.done) {
-    const newTruth = transform(truth.bind(() => lifted(next.value)));
-    yield newTruth; // Let the user do one iteration at a time.
+    if (!next.done) {
+      const newTruth = transform(truth.bind(() => lifted(next.value)));
+      yield newTruth; // Let the user do one iteration at a time.
 
-    yield* chainTruthGenerator(newTruth.bind(() => spoken("\n")),
+      yield* self({
+        truth: newTruth.bind(() => spoken("\n")),
         generator,
-        transform);
-  } else {
-    yield truth;
+        transform
+      });
+    } else {
+      yield truth;
+    }
   }
-}
+);
 
 /**
  * Returns an iterator over a range of integers.
  */
-export const range = yCombinator((self) =>
+export const range = yCombinator(self =>
   function*({ start, end }) {
     if (start <= end) {
       yield start;

--- a/src/generator-utils.js
+++ b/src/generator-utils.js
@@ -1,4 +1,5 @@
 import { lifted, spoken } from './monad-utils.js';
+import yCombinator from './y-combinator.js';
 
 /**
  * Maps each value from `generator` through `transform`, chaining IO operations
@@ -26,9 +27,14 @@ export function* chainTruthGenerator(truth, generator, transform) {
 /**
  * Returns an iterator over a range of integers.
  */
-export function* range(start, end) {
-  if (start <= end) {
-    yield start;
-    yield* range(start + 1, end);
+export const range = yCombinator((self) =>
+  function*({ start, end }) {
+    if (start <= end) {
+      yield start;
+      yield* self({
+        start: start + 1,
+        end
+      });
+    }
   }
-}
+);

--- a/src/y-combinator.js
+++ b/src/y-combinator.js
@@ -1,0 +1,4 @@
+// y combinator implementation
+export default f =>
+    (x => f(y => (x(x))(y)))
+    (x => f(y => (x(x))(y)));

--- a/test/generator-utils.js
+++ b/test/generator-utils.js
@@ -5,7 +5,7 @@ import { range } from '../src/generator-utils.js';
 describe('generator-utils', function() {
   describe('#range()', function() {
     it('should iterate over a range of values', function() {
-      let iterator = range({ start: -2, end: 1 });
+      const iterator = range({ start: -2, end: 1 });
 
       assert.equal(-2, iterator.next().value);
       assert.equal(-1, iterator.next().value);

--- a/test/generator-utils.js
+++ b/test/generator-utils.js
@@ -1,0 +1,17 @@
+import assert from 'assert';
+
+import { range } from '../src/generator-utils.js';
+
+describe('generator-utils', function() {
+  describe('#range()', function() {
+    it('should iterate over a range of values', function() {
+      let iterator = range({ start: -2, end: 1 });
+
+      assert.equal(-2, iterator.next().value);
+      assert.equal(-1, iterator.next().value);
+      assert.equal(0, iterator.next().value);
+      assert.equal(1, iterator.next().value);
+      assert.equal(true, iterator.next().done);
+    });
+  });
+});

--- a/test/integration.js
+++ b/test/integration.js
@@ -2,13 +2,20 @@ import assert from 'assert';
 
 import fizzbuzzer from '../src/fizzbuzz.js';
 import { getTheWords } from '../src/monad-utils.js';
+import yCombinator from '../src/y-combinator.js';
 
 describe('fizzbuzz', function() {
   describe('#fizzbuzzer()', function() {
     it('should match the expected output', function() {
-      let truth;
-      for (truth of fizzbuzzer()) {}
-      const words = getTheWords(truth);
+
+      const words = getTheWords((yCombinator(self =>
+        ({ fizzbuzz, finalTruth }) => {
+          const { done, value } = fizzbuzz.next();
+          return done ? finalTruth : self({ fizzbuzz, finalTruth: value });
+        })
+      )({
+        fizzbuzz: fizzbuzzer()
+      }));
 
       assert.equal(
               "1\n" +


### PR DESCRIPTION
Summary
---

This pull rewrites all of the recursive functions, wrapping them in a y combinator call.

Details
---

This allows us to export anonymous recursive functions as values. Before, we had to rely on mutation after the function was defined.

Preventing mutation will make our fizzbuzz implementation much more robust, testable and easy-to-read.

Closes https://github.com/danielj41/monad-buzz/issues/14
